### PR TITLE
ignore nomes do meio com tamanhos 3, 2 e 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,7 +357,11 @@
 		function formatName(name) {
 			let string = removeDiacritics(name);
 			string = string.replace(/[^a-zA-Z\ ]/g, "");
-			string = string.replace(/(\bde\b)|(\bda\b)|(\bdo\b)|(\bdos\b)|(\bdas\b)|(\be\b)/g, "");
+    //ignore nomes do meio com tamanhos 3, 2 e 1
+			string = string.replace(/\ [a-zA-Z][a-zA-Z][a-zA-Z]\ /g, " ");
+			string = string.replace(/\ [a-zA-Z][a-zA-Z]\ /g, " ");
+			string = string.replace(/\ [a-zA-Z]\ /g, " ");
+//			string = string.replace(/(\bde\b)|(\bda\b)|(\bdo\b)|(\bdos\b)|(\bdas\b)|(\be\b)/g, "");
 			string = string.replace(/(\s\s+)/g, " ");
 			string = abrevia(string);
 			return string.replace(/\ /g, "");


### PR DESCRIPTION
Um professor me disse que o sistema da prefeitura não ignora somente palavras-chave como "de", "do", "dos", "da", "das" e "e"... Ele ignora qualquer nome do meio que contenham menos de 3 letras, como Paz ou Gil.
obs.: achei um jeito legal de testar htmls direto do github. https://htmlpreview.github.io/?https://github.com/fhattori/institutional-email/blob/master/index.html