### PR TITLE
Ignore nomes do meio com tamanho menor ou igual a 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,8 @@
 		// Converte letras com acentos em letras sem, retira particulas de ligação de nomes e retira espaços entre palavras
 		function formatName(name) {
 			let string = removeDiacritics(name);
-      //ignore nomes do meio com tamanhos 3, 2 e 1
+			string = string.replace(/[^a-zA-Z\ ]/g, " ");
+    //ignore nomes do meio com tamanhos 3, 2 e 1
       while(string.match(/\ [a-zA-Z]{1,3}\ /)){
   			string = string.replace(/\ [a-zA-Z]{1,3}\ /g, " ");
       }

--- a/index.html
+++ b/index.html
@@ -356,8 +356,7 @@
 		// Converte letras com acentos em letras sem, retira particulas de ligação de nomes e retira espaços entre palavras
 		function formatName(name) {
 			let string = removeDiacritics(name);
-			string = string.replace(/[^a-zA-Z\ ]/g, " ");
-    //ignore nomes do meio com tamanhos 3, 2 e 1
+      //ignore nomes do meio com tamanhos 3, 2 e 1
       while(string.match(/\ [a-zA-Z]{1,3}\ /)){
   			string = string.replace(/\ [a-zA-Z]{1,3}\ /g, " ");
       }

--- a/index.html
+++ b/index.html
@@ -357,7 +357,11 @@
 		function formatName(name) {
 			let string = removeDiacritics(name);
 			string = string.replace(/[^a-zA-Z\ ]/g, "");
-			string = string.replace(/(\bde\b)|(\bda\b)|(\bdo\b)|(\bdos\b)|(\bdas\b)|(\be\b)/g, "");
+    //ignore nomes do meio com tamanhos 3, 2 e 1
+			string = string.replace(/\ [a-zA-Z][a-zA-Z][a-zA-Z]\ /g, " ");
+			string = string.replace(/\ [a-zA-Z][a-zA-Z]\ /g, " ");
+			string = string.replace(/\ [a-zA-Z]\ /g, " ");
+//			string = string.replace(/(\bde\b)|(\bda\b)|(\bdo\b)|(\bdos\b)|(\bdas\b)|(\be\b)/g, "");
 			string = string.replace(/(\s\s+)/g, " ");
 			string = abrevia(string);
 			return string.replace(/\ /g, "");

--- a/index.html
+++ b/index.html
@@ -356,11 +356,11 @@
 		// Converte letras com acentos em letras sem, retira particulas de ligação de nomes e retira espaços entre palavras
 		function formatName(name) {
 			let string = removeDiacritics(name);
-			string = string.replace(/[^a-zA-Z\ ]/g, "");
+			string = string.replace(/[^a-zA-Z\ ]/g, " ");
     //ignore nomes do meio com tamanhos 3, 2 e 1
-			string = string.replace(/\ [a-zA-Z][a-zA-Z][a-zA-Z]\ /g, " ");
-			string = string.replace(/\ [a-zA-Z][a-zA-Z]\ /g, " ");
-			string = string.replace(/\ [a-zA-Z]\ /g, " ");
+      while(string.match(/\ [a-zA-Z]{1,3}\ /)){
+  			string = string.replace(/\ [a-zA-Z]{1,3}\ /g, " ");
+      }
 //			string = string.replace(/(\bde\b)|(\bda\b)|(\bdo\b)|(\bdos\b)|(\bdas\b)|(\be\b)/g, "");
 			string = string.replace(/(\s\s+)/g, " ");
 			string = abrevia(string);


### PR DESCRIPTION
Um professor me disse que o sistema da prefeitura não ignora somente palavras-chave como "de", "do", "dos", "da", "das" e "e"... Ele ignora qualquer nome do meio que contenham menos de 3 letras, como Paz ou Gil.